### PR TITLE
support multiple comma separated patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Run `gaze --help` for a full list of options.
       --help           Print this help message
       --silent         Do not print messages
       --ignore-rename  Ignore when a file is renamed
+      --multiple       Pattern is multiple comma separated patterns
 
     Examples:
       gaze "jshint $path" "lib/**/*.js"    Runs jshint when a js file in the lib folder changes

--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ yargs
 	.option('ignore-rename', {
 		describe: 'Ignore when a file is renamed',
 		type: 'boolean'
+	})
+	.option('multiple', {
+		describe: 'Pattern is multiple comma separated patterns',
+		type: 'boolean'
 	});
 
 var argv = yargs.argv;
@@ -47,7 +51,7 @@ if (argv._.length !== 2) {
 }
 
 var command = argv._[0];
-var pattern = argv._[1];
+var pattern = argv.multiple ? [].concat(argv._[1].split(',')) : argv._[1];
 
 // Start the file watcher on the pattern
 gaze(pattern, function(err, watcher) {


### PR DESCRIPTION
Gaze supports an array of patterns to watch.  Added --multiple option to treat the pattern as a comma separated list of patterns. 

If multiple option not passed then behaviour remains as-is.
